### PR TITLE
Add ability to start aside with isShown

### DIFF
--- a/src/components/modal/ModalMixin.js
+++ b/src/components/modal/ModalMixin.js
@@ -117,6 +117,9 @@ const ModalMixin = {
   mounted() {
     this.$nextTick(() => {
       document.body.appendChild(this.$el);
+      if (this.isShow) {
+        this.active();
+      }
     });
   },
 


### PR DESCRIPTION
I want to be able show the aside based on a computed property. e.g. If the window is greater than a certain width, or when it's a narrow view if some other property `isOpen` is set to true.

```javascript
computed: {
  isShown () {
    return this.isAtLeastTablet || this.isOpen;
  }
}
```