### PR TITLE
Removing `class` property from DatePicker.

### DIFF
--- a/src/components/datepicker/Datepicker.vue
+++ b/src/components/datepicker/Datepicker.vue
@@ -30,7 +30,6 @@ export default {
     placeholder: String,
     val: String,
     value: {},
-    class: String,
   },
 
   data() {


### PR DESCRIPTION
Props named `class` aren't allowed in Vue.js since it's a reserved
propname, and there's no reason to do it anyway as it isn't used
anywhere in the component. It should be removed to silence the warning
when using the component.

Resolves #81.